### PR TITLE
Add diagnostic handling to commandService

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 				{
 					"command": "rust.cargo.doc",
 					"title": "Cargo Doc",
-					"description": "Build this project's and its dependencies' documentation"	
+					"description": "Build this project's and its dependencies' documentation"
 				},
 				{
 					"command": "rust.cargo.test",
@@ -79,6 +79,11 @@
 					"command": "rust.cargo.clean",
 					"title": "Cargo Clean",
 					"description": "Remove the target directory"
+				},
+				{
+					"command": "rust.cargo.check",
+					"title": "Cargo Check",
+					"description": "Check the project for warnings and errors"
 				}
 			],
 			"configuration": {
@@ -93,12 +98,12 @@
 					"rust.rustfmtPath": {
 						"type": "string",
 						"default": null,
-						"description": "Specifies path to Rustfmt binary if it's not in PATH"	
+						"description": "Specifies path to Rustfmt binary if it's not in PATH"
 					},
 					"rust.formatOnSave": {
 						"type": "boolean",
 						"default": false,
-						"description": "Turn on/off autoformatting file on save"	
+						"description": "Turn on/off autoformatting file on save"
 					},
 					"rust.rustLangSrcPath": {
 						"type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(FilterService.getRustModeFilter(), new FormatService()));
 
 	// Initialize status bar service
-	ctx.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(StatusBarService.toggleStatus));
+	ctx.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(StatusBarService.toggleStatus.bind(StatusBarService)));
 
 	// EXPERIMENTAL: formatting on save
 	let rustConfig = vscode.workspace.getConfiguration('rust');
@@ -43,7 +43,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		}
 		console.log(process.env);
 	}));
-	
+
 	// Commands
 	// Cargo build
 	ctx.subscriptions.push(CommandService.formatCommand('rust.cargo.build.debug', 'build'));
@@ -61,4 +61,6 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(CommandService.formatCommand('rust.cargo.update', 'update'));
 	// Cargo clean
 	ctx.subscriptions.push(CommandService.formatCommand('rust.cargo.clean', 'clean'));
+	// Cargo check
+	ctx.subscriptions.push(CommandService.formatCommand('rust.cargo.check', 'rustc', '--', '-Zno-trans'));
 }

--- a/src/services/commandService.ts
+++ b/src/services/commandService.ts
@@ -4,46 +4,102 @@ import * as path from 'path';
 
 const channelTabSize = 2;
 const channelTabName = 'Cargo';
+const errorRegex = /^(.*):(\d+):(\d+):\s+(\d+):(\d+)\s+(warning|error):\s+(.*)$/;
+
+interface RustError {
+	filename: string;
+	startLine: number;
+	startCharacter: number;
+	endLine: number;
+	endCharacter: number;
+	severity: string;
+	message: string;
+}
 
 export default class CommandService {
-	public static formatCommand(commandName: string, subCommand: string, args?: string): vscode.Disposable {
+	private static diagnostics: vscode.DiagnosticCollection;
+
+	public static formatCommand(commandName: string, ...args: string[]): vscode.Disposable {
 		return vscode.commands.registerCommand(commandName, () => {
-			this.runCargo(subCommand, args);	
+			this.runCargo(args);
 		});
 	}
-	
-	private static runCargo(command: string, args?: string): void {
+
+	private static parseDiagnostics(output: string) {
+		let errors: { [filename: string]: RustError[] } = {};
+
+		for (let line of output.split('\n')) {
+			let match = line.match(errorRegex);
+			if (match) {
+				let filename = match[1];
+				if (!errors[filename]) {
+					errors[filename] = [];
+				}
+
+				errors[filename].push({
+					filename: filename,
+					startLine: Number(match[2]) - 1,
+					startCharacter: Number(match[3]) - 1,
+					endLine: Number(match[4]) - 1,
+					endCharacter: Number(match[5]) - 1,
+					severity: match[6],
+					message: match[7]
+				});
+			}
+		}
+
+		for (let filename of Object.keys(errors)) {
+			let fileErrors = errors[filename];
+			let diagnostics = fileErrors.map((error) => {
+				let range = new vscode.Range(error.startLine, error.startCharacter, error.endLine, error.endCharacter);
+				let severity: vscode.DiagnosticSeverity;
+
+				if (error.severity === 'warning') {
+					severity = vscode.DiagnosticSeverity.Warning;
+				} else if (error.severity === 'error') {
+					severity = vscode.DiagnosticSeverity.Error;
+				}
+
+				return new vscode.Diagnostic(range, error.message, severity);
+			})
+
+			let uri = vscode.Uri.file(path.join(vscode.workspace.rootPath, filename));
+			this.diagnostics.set(uri, diagnostics);
+		}
+	}
+
+	private static runCargo(args: string[]): void {
+		if (!this.diagnostics) {
+			this.diagnostics = vscode.languages.createDiagnosticCollection('rust');
+		}
+
 		let channel = vscode.window.createOutputChannel(channelTabName);
 		let cwd = vscode.workspace.rootPath;
-		args = args || '';
-		
+
 		channel.clear();
 		channel.show(channelTabSize);
-		channel.appendLine(this.formTitle(command, args));
-		
-		let params: string[] = [command];
-		if (args.length > 0) {
-			params.push(args);
-		}
-		
-		let startTime = new Date().getMilliseconds();
-		let cargoProc = cp.spawn('cargo', params, { cwd, env: process.env });
+		channel.appendLine(this.formTitle(args));
+
+		let startTime = Date.now();
+		let cargoProc = cp.spawn('cargo', args, { cwd, env: process.env });
+		let output = '';
 		cargoProc.stdout.on('data', data => {
 			channel.append(data.toString());
 		});
 		cargoProc.stderr.on('data', data => {
+			output += data.toString();
 			channel.append(data.toString());
 		});
 		cargoProc.on('exit', code => {
 			cargoProc.removeAllListeners();
-			let endTime = new Date().getMilliseconds();
-			channel.append(`\n"cargo ${command} ${args}" completed with code ${code}`);
+			let endTime = Date.now();
+			channel.append(`\n"cargo ${args.join(' ')}" completed with code ${code}`);
 			channel.append(`\nIt took approximately ${(endTime - startTime) / 1000} seconds`);
+			this.parseDiagnostics(output);
 		});
 	}
-	
-	private static formTitle(command: string, args: string): string {
-		if (args.length > 0) return `Running "cargo ${command} ${args}":\n`;
-		return `Running "cargo ${command}":\n`
+
+	private static formTitle(args: string[]): string {
+		return `Running "cargo ${args.join(' ')}":\n`;
 	}
 }


### PR DESCRIPTION
Implement diagnostics for cargo output (warning and error highlighting), and add command Cargo Check.

Linting should probably be implemented by debouncing document edits and calling `cargo check`. The command service should also keep a reference to the command currently being executed, and terminate it before running any other commands, this implies that there should be a `force` argument, that user run commands is set to true, and internally run commands sets to false, like this, when the user runs a command in the middle of a lint, the lint will stop to run the user command, but if the lint runs while a user command is running, it will do nothing.