### PR TITLE
Standard messages for missing executables

### DIFF
--- a/src/services/commandService.ts
+++ b/src/services/commandService.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as cp from 'child_process';
 import * as path from 'path';
 
-import PathService from './pathService'; 
+import PathService from './pathService';
 
 const channelTabSize = 2;
 const channelTabName = 'Cargo';
@@ -74,7 +74,7 @@ export default class CommandService {
 		if (!this.diagnostics) {
 			this.diagnostics = vscode.languages.createDiagnosticCollection('rust');
 		}
-		
+
 		this.diagnostics.clear();
 
 		let channel = vscode.window.createOutputChannel(channelTabName);
@@ -88,13 +88,18 @@ export default class CommandService {
 		const startTime = Date.now();
 		let output = '';
 		let cargoProc = cp.spawn(cargoPath, args, { cwd, env: process.env });
-		
+
 		cargoProc.stdout.on('data', data => {
 			channel.append(data.toString());
 		});
 		cargoProc.stderr.on('data', data => {
 			output += data.toString();
 			channel.append(data.toString());
+		});
+		cargoProc.on('error', error => {
+			if (error.code === 'ENOENT') {
+				vscode.window.showInformationMessage('The "cargo" command is not available. Make sure it is installed.');
+			}
 		});
 		cargoProc.on('exit', code => {
 			cargoProc.removeAllListeners();

--- a/src/services/suggestService.ts
+++ b/src/services/suggestService.ts
@@ -96,6 +96,11 @@ export default class SuggestService {
         this.providers.forEach(disposable => disposable.dispose());
         this.providers = [];
 
+        if (error && error.code === 'ENOENT') {
+            vscode.window.showInformationMessage('The "racer" command is not available. Make sure it is installed.');
+            return;
+        }
+
         if (error === 0) {
             return;
         }


### PR DESCRIPTION
Add missing executable messages for `cargo` and `racer`, using the same format as the message for `rustfmt`.

Fixes https://github.com/saviorisdead/RustyCode/issues/22.

This will probably need to be rebased if you merge #24, just send me a message and I will rebase so you can merge smoothly.