### PR TITLE
Run parseDiagnostics on failed CargoTasks

### DIFF
--- a/src/services/commandService.ts
+++ b/src/services/commandService.ts
@@ -89,10 +89,12 @@ class CargoTask {
                 const endTime = Date.now();
                 this.channel.append(this, `\n"${task}" completed with code ${code}`);
                 this.channel.append(this, `\nIt took approximately ${(endTime - startTime) / 1000} seconds`);
+
                 if (code === 0 || this.interrupted) {
                     resolve(this.interrupted ? '' : output);
                 } else {
-                    reject(code);
+                    vscode.window.showWarningMessage(`Cargo unexpectedly stopped with code ${code}`);
+                    reject(output);
                 }
             });
         });
@@ -150,11 +152,11 @@ export default class CommandService {
             }
         }
 
+        this.diagnostics.clear();
         if (!Object.keys(errors).length) {
             return;
         }
 
-        this.diagnostics.clear();
         for (let filename of Object.keys(errors)) {
             let fileErrors = errors[filename];
             let diagnostics = fileErrors.map((error) => {
@@ -195,8 +197,8 @@ export default class CommandService {
 
         this.currentTask.execute().then(output => {
             this.parseDiagnostics(output);
-        }, exitCode => {
-            vscode.window.showWarningMessage(`Cargo unexpectedly stopped with code ${exitCode}`);
+        }, output => {
+            this.parseDiagnostics(output);
         }).then(() => {
             this.currentTask = null;
         });


### PR DESCRIPTION
This pull request makes the promise returned form CargoTask.execute resolve into the output of the cargo task and CommandService.runCargo to run that output through parseDiagnostics.

This makes errors from failed cargo builds show up as diagnostics.

Fix for #50  

![screen shot 2015-12-14 at 21 09 34](https://cloud.githubusercontent.com/assets/392416/11792641/67206000-a2a7-11e5-9a23-cfc8a98f7cd4.png)
