### PR TITLE
Check function name when showing signature

### DIFF
--- a/src/services/suggestService.ts
+++ b/src/services/suggestService.ts
@@ -315,16 +315,25 @@ export default class SuggestService {
             return null;
         }
 
+        let name = document.getText(document.getWordRangeAtPosition(startPos));
+
         let command = `complete-with-snippet ${startPos.line + 1} ${startPos.character - 1} ${document.fileName} ${this.tmpFile}\n`;
         return this.runCommand(command).then((lines) => {
             lines = lines.map(l => l.trim()).join('').split('MATCH ').slice(1);
-            if (lines.length === 0) {
+
+            let parts: string[] = [];
+            for (let line of lines) {
+                parts = line.split(';');
+                if (parts[0] === name) {
+                    break;
+                }
+            }
+
+            if (parts[0] !== name) {
                 return null;
             }
 
-            let parts = lines[0].split(';');
             let args = parts[1].match(/\${\d+:\w+}/g);
-            let name = parts[0];
             let type = parts[5];
             let definition = parts[6];
 


### PR DESCRIPTION
This pull request makes the suggest service check for the correct function name when showing the signature.

New behaviour (shows signature of `say` when calling `say`):
![screen shot 2015-12-26 at 22 03 28](https://cloud.githubusercontent.com/assets/392416/12007937/950ace28-ac1c-11e5-87ae-573fb4585351.png)
![screen shot 2015-12-26 at 22 03 51](https://cloud.githubusercontent.com/assets/392416/12007936/94fef8f0-ac1c-11e5-9e03-96254a1366ab.png)

Old behaviour (shows signature of `say_hello` when calling `say`):
![screen shot 2015-12-26 at 21 59 48](https://cloud.githubusercontent.com/assets/392416/12007933/59aee620-ac1c-11e5-8443-b5d4c91ff814.png)
![screen shot 2015-12-26 at 21 59 55](https://cloud.githubusercontent.com/assets/392416/12007934/59b18a4c-ac1c-11e5-8365-f579ba979005.png)
