### PR TITLE
Added option to cargo check on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This extension adds advanced language support for the Rust language to VS Code, 
 - Autocompletion (using `racer`)
 - Go To Definition (using `racer`)
 - Format (using `rustfmt`) *formatOnSave is experimental*
+- Linter (using `cargo check`) *checkOnSave is experimental*
 - Cargo tasks (Open Command Pallete and they will be there)
 - [_not implemented yet_] Snippets
 
@@ -39,6 +40,7 @@ The following Visual Studio Code settings are available for the RustyCode extens
 	"rust.rustfmtPath": null, // Specifies path to Rustfmt binary if it's not in PATH
 	"rust.cargoPath": null, // Specifies path to Cargo binary if it's not in PATH
 	"rust.formatOnSave": false, // Turn on/off autoformatting file on save (EXPERIMENTAL)
+	"rust.checkOnSave": false // Turn on/off cargo check project on save (EXPERIMENTAL)
 }
 ```
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
         }
         vscode.commands.executeCommand('editor.action.format');
     }));
-    
+
     // EXPERIMENTAL: cargo check on save
     ctx.subscriptions.push(vscode.workspace.onDidSaveTextDocument(() => {
         if (!rustConfig['checkOnSave']) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,19 +26,16 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
     // EXPERIMENTAL: formatting on save
     let rustConfig = vscode.workspace.getConfiguration('rust');
-    ctx.subscriptions.push(vscode.workspace.onDidSaveTextDocument(() => {
-        if (!rustConfig['formatOnSave']) {
+    ctx.subscriptions.push(vscode.workspace.onDidSaveTextDocument((event) => {
+        if (event.languageId !== 'rust') {
             return;
         }
-        vscode.commands.executeCommand('editor.action.format');
-    }));
-
-    // EXPERIMENTAL: cargo check on save
-    ctx.subscriptions.push(vscode.workspace.onDidSaveTextDocument(() => {
-        if (!rustConfig['checkOnSave']) {
-            return;
+        if (rustConfig['formatOnSave']) {
+            vscode.commands.executeCommand('editor.action.format');
         }
-        vscode.commands.executeCommand('rust.cargo.check');
+        if (rustConfig['checkOnSave']) {
+            vscode.commands.executeCommand('rust.cargo.check');
+        }
     }));
 
     // Watch for configuration changes for ENV

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,14 @@ export function activate(ctx: vscode.ExtensionContext): void {
         }
         vscode.commands.executeCommand('editor.action.format');
     }));
+    
+    // EXPERIMENTAL: cargo check on save
+    ctx.subscriptions.push(vscode.workspace.onDidSaveTextDocument(() => {
+        if (!rustConfig['checkOnSave']) {
+            return;
+        }
+        vscode.commands.executeCommand('rust.cargo.check');
+    }));
 
     // Watch for configuration changes for ENV
     ctx.subscriptions.push(vscode.workspace.onDidChangeConfiguration(() => {


### PR DESCRIPTION
I've been using Atom before, there is a plugin 'rust-linter' that runs `cargo check` on save and highlights errors and warnings.

This PR adds simmilar option to RustyCode based on `rust.cargo.check`. It is as experimental as `formatOnSave`, since it uses the same code. The name of a new option is `checkOnSave`.

I've also added a pair of lines to README.md to folow this addition.