### PR TITLE
Add option to use clippy to lint project on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This extension adds advanced language support for the Rust language to VS Code, 
 - Go To Definition (using `racer`)
 - Format (using `rustfmt`) *formatOnSave is experimental*
 - Linter (using `cargo check`) *checkOnSave is experimental*
+	- Linting can be done via `cargo clippy` if `cargo-clippy` is installed *checkWithClippy is experimental*
 - Cargo tasks (Open Command Pallete and they will be there)
 - [_not implemented yet_] Snippets
 
@@ -40,7 +41,8 @@ The following Visual Studio Code settings are available for the RustyCode extens
 	"rust.rustfmtPath": null, // Specifies path to Rustfmt binary if it's not in PATH
 	"rust.cargoPath": null, // Specifies path to Cargo binary if it's not in PATH
 	"rust.formatOnSave": false, // Turn on/off autoformatting file on save (EXPERIMENTAL)
-	"rust.checkOnSave": false // Turn on/off cargo check project on save (EXPERIMENTAL)
+	"rust.checkOnSave": false, // Turn on/off `cargo check` project on save (EXPERIMENTAL)
+	"rust.checkWithClippy": false // Turn on/off `cargo clippy` project on save (EXPERIMENTAL) (cargo-clippy should be installed)
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -148,6 +148,16 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Turn on/off autoformatting file on save"
+                },
+                "rust.checkOnSave": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Turn on/off autochecking file on save using cargo check"
+                },
+                "rust.checkWithClippy": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use cargo clippy to lint instead of cargo check"
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,11 @@ export function activate(ctx: vscode.ExtensionContext): void {
             vscode.commands.executeCommand('editor.action.format');
         }
         if (rustConfig['checkOnSave']) {
-            vscode.commands.executeCommand('rust.cargo.check');
+            if (rustConfig['checkWithClippy']) {
+                vscode.commands.executeCommand('rust.cargo.clippy');
+            } else {
+                vscode.commands.executeCommand('rust.cargo.check');
+            }
         }
     }));
 
@@ -70,6 +74,8 @@ export function activate(ctx: vscode.ExtensionContext): void {
     ctx.subscriptions.push(CommandService.formatCommand('rust.cargo.clean', 'clean'));
     // Cargo check
     ctx.subscriptions.push(CommandService.formatCommand('rust.cargo.check', 'rustc', '--', '-Zno-trans'));
+    // Cargo clippy
+    ctx.subscriptions.push(CommandService.formatCommand('rust.cargo.clippy', 'clippy'));
 
     // Cargo terminate
     ctx.subscriptions.push(CommandService.stopCommand('rust.cargo.terminate'));


### PR DESCRIPTION
[Clippy](https://github.com/Manishearth/rust-clippy) is a powerful linter for Rust with some really useful warnings. This PR allows RustyCode to lint code on save (if `checkOnSave` is enabled) through [`cargo-clippy`](https://github.com/White-Oak/cargo-clippy) subcommand (if `useClippyInsteadOfCheck` is enabled). `cargo-clippy` should be installed (via `cargo install`) to use it.