### PR TITLE
Build is allowed when Cargo.toml is chosen

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
                     "Rust"
                 ],
                 "extensions": [
+                    ".toml",
                     ".rs"
                 ]
             }


### PR DESCRIPTION
Currently when you try to build when Cargo.toml is chosen you cannot.