### PR TITLE
Fix breakage of ctrl+hover functionality on racer daemon restart

### DIFF
--- a/src/services/suggestService.ts
+++ b/src/services/suggestService.ts
@@ -79,6 +79,7 @@ export default class SuggestService {
     public stop(): void {
         this.stopDaemon(0);
         this.stopListeners();
+        this.clearCommandCallbacks();
     }
 
     public restart(): void {
@@ -118,6 +119,10 @@ export default class SuggestService {
     private stopListeners(): void {
         this.listeners.forEach(disposable => disposable.dispose());
         this.listeners = [];
+    }
+
+    private clearCommandCallbacks(): void {
+        this.commandCallbacks.forEach(callback => callback([]));
     }
 
     private showErrorBuffer(): void {


### PR DESCRIPTION
**Supersedes #82 to free up my master branch**

Currently, there is a bug where the ctrl+hover functionality of RustyCode is broken after a racer daemon restart. This can be demonstrated by:

1. Open a Rust source file
2. Hold down ctrl and hover a few symbols; observe that valid symbols are underlined and their definitions pop up
3. Hover over a comment or a string and racer will crash
4. Close the error message, triggering a restart of RustyCode's suggestions provider
5. The ctrl+hover functionality is now broken

The breakage is due to a callback never getting called back after racer crashes. This makes VS Code wait forever for a response, blocking all future calls on ctrl+hover.

The fix is simply to invoke the all the pending callbacks before relaunching the racer daemon.