### PR TITLE
Fix launch.json relative paths

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outDir": "${workspaceRoot}/out/src",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outDir": "${workspaceRoot}/out/test",
 			"preLaunchTask": "npm"
 		}
 	]


### PR DESCRIPTION
The new release of VS Code (0.10.10) requires paths in launch.json to be absolute. This PR fixes that.