### PR TITLE
add 'help' and 'note' modes to diagnostic detection

### DIFF
--- a/src/services/commandService.ts
+++ b/src/services/commandService.ts
@@ -5,7 +5,7 @@ import kill = require('tree-kill');
 
 import PathService from './pathService';
 
-const errorRegex = /^(.*):(\d+):(\d+):\s+(\d+):(\d+)\s+(warning|error):\s+(.*)$/;
+const errorRegex = /^(.*):(\d+):(\d+):\s+(\d+):(\d+)\s+(warning|error|note|help):\s+(.*)$/;
 
 interface RustError {
     filename: string;
@@ -223,6 +223,10 @@ export default class CommandService {
                     severity = vscode.DiagnosticSeverity.Warning;
                 } else if (error.severity === 'error') {
                     severity = vscode.DiagnosticSeverity.Error;
+                } else if (error.severity === 'note') {
+                    severity = vscode.DiagnosticSeverity.Information;
+                } else if (error.severity === 'help') {
+                    severity = vscode.DiagnosticSeverity.Hint;
                 }
 
                 return new vscode.Diagnostic(range, error.message, severity);


### PR DESCRIPTION
`rustc` occasionally emits diagnostics prefixed with `note:` and `help:`. This is most prevalent with the borrow and region checkers, which will emit `note` diagnostics at the source of the borrow and the region that a borrow is valid, respectively.

Here's a code sample before this change:

![before_vscode](https://cloud.githubusercontent.com/assets/1871912/13835175/9a95465e-ebb2-11e5-95f6-f326fc7296e6.png)

And after:

![after_vscode](https://cloud.githubusercontent.com/assets/1871912/13835177/9ebe94a6-ebb2-11e5-858b-5932118d2a5a.png)

With this change the first `x` is highlighted green, as `rustc` indicates it as immutable binding.

Region checker diagnostics tend to span the entire region whose lifetime a borrow escapes, like this:
![region_check](https://cloud.githubusercontent.com/assets/1871912/13835186/bafb9f38-ebb2-11e5-8c8d-81fe013ebd32.png)

This ends up with a swath of green highlighting. This isn't the best, I think, but other editors have this same problem (a side effect of the spans that `rustc` gives us). You can see also in this example a borrow checker diagnostic highlighting green the right bracket indicating the location where the borrow ends.

The borrow checker diagnostics are improved a lot by this change, since we can now mouse over the source of the borrow to get the diagnostic information:

![borrow_check](https://cloud.githubusercontent.com/assets/1871912/13835281/8bf57b2c-ebb3-11e5-91db-4db9ee4fd3f3.png)




