### PR TITLE
Enable check with `cargo build`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This extension adds advanced language support for the Rust language to VS Code, 
 - Format (using `rustfmt`) *formatOnSave is experimental*
 - Linter *checkOnSave is experimental*
 - Linting can be done via  *checkWith is experimental*
-	- `check` if `cargo-check` is installed. This is the default.
+	- `check`. This is the default.
 	- `clippy` if `cargo-clippy` is installed
 	- `build`
 - Cargo tasks (Open Command Pallete and they will be there)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ This extension adds advanced language support for the Rust language to VS Code, 
 - Autocompletion (using `racer`)
 - Go To Definition (using `racer`)
 - Format (using `rustfmt`) *formatOnSave is experimental*
-- Linter (using `cargo check`) *checkOnSave is experimental*
-- Linting can be done via `cargo clippy` if `cargo-clippy` is installed *checkWithClippy is experimental*
+- Linter *checkOnSave is experimental*
+- Linting can be done via  *checkWith is experimental*
+	- `check` if `cargo-check` is installed
+	- `clippy` if `cargo-clippy` is installed
+	- `build`
 - Cargo tasks (Open Command Pallete and they will be there)
 - [_not implemented yet_] Snippets
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This extension adds advanced language support for the Rust language to VS Code, 
 - Format (using `rustfmt`) *formatOnSave is experimental*
 - Linter *checkOnSave is experimental*
 - Linting can be done via  *checkWith is experimental*
-	- `check` if `cargo-check` is installed
+	- `check` if `cargo-check` is installed. This is the default.
 	- `clippy` if `cargo-clippy` is installed
 	- `build`
 - Cargo tasks (Open Command Pallete and they will be there)
@@ -45,7 +45,7 @@ The following Visual Studio Code settings are available for the RustyCode extens
 	"rust.cargoPath": null, // Specifies path to Cargo binary if it's not in PATH
 	"rust.formatOnSave": false, // Turn on/off autoformatting file on save (EXPERIMENTAL)
 	"rust.checkOnSave": false, // Turn on/off `cargo check` project on save (EXPERIMENTAL)
-	"rust.checkWithClippy": false // Turn on/off `cargo clippy` project on save (EXPERIMENTAL) (cargo-clippy should be installed)
+	"rust.checkWith": "build" // Specifies the linter to use. (EXPERIMENTAL)
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -155,10 +155,10 @@
                     "default": false,
                     "description": "Turn on/off autochecking file on save using cargo check"
                 },
-                "rust.checkWithClippy": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Use cargo clippy to lint instead of cargo check"
+                "rust.checkWith": {
+                    "type": "string",
+                    "default": "check",
+                    "description": "Choose between check, clippy and build to lint"
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,10 +34,10 @@ export function activate(ctx: vscode.ExtensionContext): void {
         }
         if (rustConfig['checkOnSave']) {
             switch (rustConfig['checkWith']) {
-            case "clippy":
+            case 'clippy':
                 vscode.commands.executeCommand('rust.cargo.clippy');
                 break;
-            case "build":
+            case 'build':
                 vscode.commands.executeCommand('rust.cargo.build.debug');
                 break;
             default:

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,9 +33,14 @@ export function activate(ctx: vscode.ExtensionContext): void {
             vscode.commands.executeCommand('editor.action.format');
         }
         if (rustConfig['checkOnSave']) {
-            if (rustConfig['checkWithClippy']) {
+            switch (rustConfig['checkWith']) {
+            case "clippy":
                 vscode.commands.executeCommand('rust.cargo.clippy');
-            } else {
+                break;
+            case "build":
+                vscode.commands.executeCommand('rust.cargo.build.debug');
+                break;
+            default:
                 vscode.commands.executeCommand('rust.cargo.check');
             }
         }


### PR DESCRIPTION
Inspiration taken from Atom's [linter-rust](https://github.com/AtomLinter/linter-rust/blob/master/lib/linter-rust.coffee#L113). The main problem of using `cargo check` is due to the this https://github.com/rsolomo/cargo-check/issues/4 .