### PR TITLE
Set the TERM environment variable when calling rustfmt

### DIFF
--- a/src/services/formatService.ts
+++ b/src/services/formatService.ts
@@ -92,7 +92,8 @@ export default class FormatService implements vscode.DocumentFormattingEditProvi
             fs.writeFileSync(fileName, document.getText());
 
             let args = ['--skip-children', '--write-mode=diff', fileName];
-            cp.execFile(PathService.getRustfmtPath(), args, (err, stdout, stderr) => {
+            let env = { TERM: process.env.TERM || 'xterm' };
+            cp.execFile(PathService.getRustfmtPath(), args, {env: env}, (err, stdout, stderr) => {
                 try {
                     if (err && (<any>err).code === 'ENOENT') {
                         vscode.window.showInformationMessage('The "rustfmt" command is not available. Make sure it is installed.');


### PR DESCRIPTION
This PR allows us to bypass a problem in `rustfmt` where it'll panic when the environment variable TERM isn't set (https://github.com/rust-lang-nursery/rustfmt/issues/978). If TERM isn't set, default to "xterm" as a best guess.

This might fix https://github.com/saviorisdead/RustyCode/issues/119, but it's hard to be sure since everyone has a different set up.