### PR TITLE
Fixed rustfmt error handling to continue when non-fatal errors are encountered

### DIFF
--- a/src/services/formatService.ts
+++ b/src/services/formatService.ts
@@ -99,7 +99,13 @@ export default class FormatService implements vscode.DocumentFormattingEditProvi
                         vscode.window.showInformationMessage('The "rustfmt" command is not available. Make sure it is installed.');
                         return resolve([]);
                     }
-                    if ((err || stderr.length) && (<any>err).code !== 3) {
+
+                    // rustfmt will return with exit code 3 when it encounters code that could not
+                    // be automatically resolved. However, it will continue to format the rest of the file.
+                    let hasFatalError = (err && (err as any).code !== 3);
+
+                    // If an error is encountered with any other exit code, inform the user of the error.
+                    if ((err || stderr.length) && hasFatalError) {
                         vscode.window.showWarningMessage('Cannot format due to syntax errors');
                         return resolve([]);
                     }

--- a/src/services/formatService.ts
+++ b/src/services/formatService.ts
@@ -99,7 +99,7 @@ export default class FormatService implements vscode.DocumentFormattingEditProvi
                         vscode.window.showInformationMessage('The "rustfmt" command is not available. Make sure it is installed.');
                         return resolve([]);
                     }
-                    if (err || stderr.length) {
+                    if ((err || stderr.length) && (<any>err).code !== 3) {
                         vscode.window.showWarningMessage('Cannot format due to syntax errors');
                         return resolve([]);
                     }


### PR DESCRIPTION
When using the extension to format code that contains a line that cannot be formatted (but is non-fatal), rustfmt will output a warning and continue formatting the rest of the file. Rustfmt sets the exit code to `3`, which the extension interprets as a fatal error and emits the 'Cannot format due to syntax errors' message.

I've added a check to exclude the error condition in the event that such a warning is encountered.