### PR TITLE
Add support for JSON error format and new (RUST_NEW_ERROR_FORMAT=true) error style

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,11 @@
           "type": "string",
           "default": "check",
           "description": "Choose between check, clippy and build to lint"
+        },
+        "rust.useJsonErrors": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable the use of JSON errors (requires Rust 1.7+). Note: This is an unstable feature of Rust and is still in the process of being stablised"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -181,6 +181,11 @@
           "type": "boolean",
           "default": false,
           "description": "Enable the use of JSON errors (requires Rust 1.7+). Note: This is an unstable feature of Rust and is still in the process of being stablised"
+        },
+        "rust.useNewErrorFormat": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use the new Rust error format (RUST_NEW_ERROR_FORMAT=true). Note: This flag is mutually exclusive with `useJsonErrors`."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import FilterService from './services/filterService';
 import StatusBarService from './services/statusBarService';
 import SuggestService from './services/suggestService';
 import PathService from './services/pathService';
-import CommandService from './services/commandService';
+import {CommandService, ErrorFormat} from './services/commandService';
 import WorkspaceSymbolService from './services/workspaceSymbolService';
 import DocumentSymbolService from './services/documentSymbolService';
 
@@ -77,14 +77,46 @@ export function activate(ctx: vscode.ExtensionContext): void {
         }
     }));
 
+    // Make sure we end up at one error format. If multiple are set, then prompt the user on how they want to proceed.
+    // Fix (Change their settings) or Ignore (Use JSON as it comes first in the settings)
+    // This should run both on activation and when the config changes to ensure we stay in sync with their preference.
+    const updateErrorFormatFlags = () => {
+        const rustConfig = vscode.workspace.getConfiguration('rust');
+
+        if (rustConfig['useJsonErrors'] === true && rustConfig['useNewErrorFormat'] === true) {
+            let ignoreOption = <vscode.MessageItem>{ title: 'Ignore (Use JSON)' };
+            let updateSettingsOption = <vscode.MessageItem>{ title: 'Update Settings' };
+
+            vscode.window.showWarningMessage(
+                'Note: rust.useJsonErrors and rust.useNewErrorFormat are mutually exclusive with each other. Which would you like to do?',
+                ignoreOption, updateSettingsOption).then((option) => {
+                    // Nothing selected
+                    if (option == null) {
+                        return;
+                    }
+
+                    if (option === ignoreOption) {
+                        CommandService.errorFormat = ErrorFormat.JSON;
+                    } else if (updateSettingsOption) {
+                        vscode.commands.executeCommand('workbench.action.openGlobalSettings');
+                    }
+                });
+        } else {
+            CommandService.updateErrorFormat();
+        }
+    };
+
     // Watch for configuration changes for ENV
     ctx.subscriptions.push(vscode.workspace.onDidChangeConfiguration(() => {
+        updateErrorFormatFlags();
+
         let rustLangPath = PathService.getRustLangSrcPath();
         if (process.env['RUST_SRC_PATH'] !== rustLangPath) {
             process.env['RUST_SRC_PATH'] = rustLangPath;
         }
-        console.log(process.env);
     }));
+
+    updateErrorFormatFlags();
 
     // Commands
     // Cargo build

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,8 +56,8 @@ export function activate(ctx: vscode.ExtensionContext): void {
             }).then(() => {
                 alreadyAppliedFormatting.delete(document);
             }, () => {
-				// Catch any errors and ignore so that we still trigger 
-				// the file save.
+                // Catch any errors and ignore so that we still trigger 
+                // the file save.
             });
         }
 

--- a/src/services/commandService.ts
+++ b/src/services/commandService.ts
@@ -305,17 +305,21 @@ export default class CommandService {
         }
 
         for (let span of errorJson.spans) {
-            let error: RustError = {
-                filename: span.file_name,
-                startLine: span.line_start,
-                startCharacter: span.column_start,
-                endLine: span.line_end,
-                endCharacter: span.column_end,
-                severity: errorJson.level,
-                message: errorJson.message
-            };
+            // Only add the primary span, as VSCode orders the problem window by the 
+            // error's range, which causes a lot of confusion if there are duplicate messages.
+            if (span.is_primary) {
+                let error: RustError = {
+                    filename: span.file_name,
+                    startLine: span.line_start,
+                    startCharacter: span.column_start,
+                    endLine: span.line_end,
+                    endCharacter: span.column_end,
+                    severity: errorJson.level,
+                    message: errorJson.message
+                };
 
-            errors.push(error);
+                errors.push(error);
+            }
         }
 
         return true;


### PR DESCRIPTION
The Cargo output is somewhat preserved by manually emitting Rust formatted errors, although it is not a complete solution. It does, however, provide a much better output than a giant JSON blob.

As per the discussion in #146, this uses `RUSTFLAGS` while the `error-format` feature is unstable. Hopefully `error-format` makes its way into Cargo so we can issue JSON builds from the IDE without `RUSTFLAGS` as this currently invalidates the internal fingerprint in `rustc`.

I've also refactored the error parsing to be a little more generic so future additions (like parsing the new Rust error format) can be added trivially.

***Edit:*** Went ahead and added support for the new error format (`RUST_NEW_ERROR_FORMAT=true`) that is set to become the new default in the future. 