### PR TITLE
Add support for rustsym 0.3.0 which enables searching for macros

### DIFF
--- a/src/rustSymbols.ts
+++ b/src/rustSymbols.ts
@@ -9,7 +9,9 @@ const rustKindToCodeKind: { [key: string]: vscode.SymbolKind } = {
     'function': vscode.SymbolKind.Function,
     'constant': vscode.SymbolKind.Constant,
     'static': vscode.SymbolKind.Constant,
-    'enum': vscode.SymbolKind.Enum
+    'enum': vscode.SymbolKind.Enum,
+    // Don't really like this, but this was the best alternative given the absense of vscode.SymbolKind.Macro
+    'macro': vscode.SymbolKind.Function
 };
 
 function getSymbolKind(kind: string): vscode.SymbolKind {


### PR DESCRIPTION
Adds support for [rustsym](https://github.com/trixnz/rustsym) 0.3.0 which enables searching for macros via Go To Symbol.