### PR TITLE
Added support for exit code 4 when using diff mode in recent(master) versions of rustfmt

### DIFF
--- a/src/services/formatService.ts
+++ b/src/services/formatService.ts
@@ -101,13 +101,15 @@ export default class FormatService implements vscode.DocumentFormattingEditProvi
                     }
 
                     // rustfmt will return with exit code 3 when it encounters code that could not
-                    // be automatically resolved. However, it will continue to format the rest of the file.
-                    let hasFatalError = (err && (err as any).code !== 3);
+                    // be automatically formatted. However, it will continue to format the rest of the file.
+                    // New releases will return exit code 4 when the write mode is diff and a valid diff is provided.
+                    // For these reasons, if the exit code is 1 or 2, then it should be treated as an error.
+                    let hasFatalError = (err && (err as any).code < 3);
 
                     // If an error is encountered with any other exit code, inform the user of the error.
                     if ((err || stderr.length) && hasFatalError) {
-                        vscode.window.showWarningMessage('Cannot format due to syntax errors');
-                        return resolve([]);
+                        vscode.window.setStatusBarMessage('$(alert) Cannot format due to syntax errors', 5000);
+                        return reject();
                     }
 
                     return resolve(this.parseDiff(document.uri, stdout));


### PR DESCRIPTION
Also changed the `Cannot format due to syntax errors` nag to show in the status bar which will disappear after 5 seconds, rather than a big popup as this becomes tedious after a while. Thoughts?

Exit code 4 reference PR: https://github.com/rust-lang-nursery/rustfmt/issues/906