### PR TITLE
Added a separate check command for library

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This extension adds advanced language support for the Rust language to VS Code, 
 - Format (using `rustfmt`)
 - Linter *checkOnSave is experimental*
 - Linting can be done via  *checkWith is experimental*
-	- `check`. This is the default.
+	- `check`. This is the default. Runs rust compiler but skips codegen pass.
+	- `check-lib`. As above, but is limited only to library if project has library + multiple binaries
 	- `clippy` if `cargo-clippy` is installed
 	- `build`
 - Cargo tasks (Open Command Pallete and they will be there)

--- a/package.json
+++ b/package.json
@@ -123,6 +123,11 @@
         "description": "Check the project for warnings and errors"
       },
       {
+        "command": "rust.cargo.check.lib",
+        "title": "Cargo: Check Library",
+        "description": "Check the main library of the project for warnings and errors"
+      },
+      {
         "command": "rust.cargo.terminate",
         "title": "Cargo: Terminate Running Task",
         "description": "Terminate currently running cargo task"
@@ -175,7 +180,7 @@
         "rust.checkWith": {
           "type": "string",
           "default": "check",
-          "description": "Choose between check, clippy and build to lint"
+          "description": "Choose between check, check-lib, clippy and build to lint"
         },
         "rust.useJsonErrors": {
           "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
             }).then(() => {
                 alreadyAppliedFormatting.delete(document);
             }, () => {
-                // Catch any errors and ignore so that we still trigger 
+                // Catch any errors and ignore so that we still trigger
                 // the file save.
             });
         }
@@ -69,6 +69,9 @@ export function activate(ctx: vscode.ExtensionContext): void {
                         break;
                     case 'build':
                         vscode.commands.executeCommand('rust.cargo.build.debug');
+                        break;
+                    case 'check-lib':
+                        vscode.commands.executeCommand('rust.cargo.check.lib');
                         break;
                     default:
                         vscode.commands.executeCommand('rust.cargo.check');
@@ -142,6 +145,8 @@ export function activate(ctx: vscode.ExtensionContext): void {
     ctx.subscriptions.push(CommandService.formatCommand('rust.cargo.clean', 'clean'));
     // Cargo check
     ctx.subscriptions.push(CommandService.formatCommand('rust.cargo.check', 'rustc', '--', '-Zno-trans'));
+    // Cargo check lib
+    ctx.subscriptions.push(CommandService.formatCommand('rust.cargo.check.lib', 'rustc', '--lib', '--', '-Zno-trans'));
     // Cargo clippy
     ctx.subscriptions.push(CommandService.formatCommand('rust.cargo.clippy', 'clippy'));
     // Racer crash error


### PR DESCRIPTION
The main problem this tries to solve is that in a complex project which
consists of a library and binaries which use it it's much more important
to iterate on the library itself rather than on binaries and `check`
command is pretty important.

While solving this issue in a general case might be complicated (it
needs binary name), the solution for library case is quite simple - all
we need to do is to pass `--lib`.

This commit adds additional internal command `rust.cargo.check.lib` and
exposes it as:
1. "Cargo: Check Library" task
2. `cargo-lib` as a new option for `checkWith` workspace configuration
   value

So the easiest way is to set `checkWith` to `cargo-lib`

Fixes #131