### PR TITLE
Add rust.cargoEnv configuration key

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following Visual Studio Code settings are available for the RustyCode extens
 	"rust.rustsymPath": null, // Specifies path to Rustsym binary if it's not in PATH
 	"rust.cargoPath": null, // Specifies path to Cargo binary if it's not in PATH
 	"rust.cargoHomePath": null, // Path to Cargo home directory, mostly needed for racer. Needed only if using custom rust installation.
+	"rust.cargoEnv": null, // Specifies custom variables to set when running cargo. Useful for crates which use env vars in their build.rs (like openssl-sys).
 	"rust.formatOnSave": false, // Turn on/off autoformatting file on save (EXPERIMENTAL)
 	"rust.checkOnSave": false, // Turn on/off `cargo check` project on save (EXPERIMENTAL)
 	"rust.checkWith": "build", // Specifies the linter to use. (EXPERIMENTAL)

--- a/package.json
+++ b/package.json
@@ -167,6 +167,11 @@
           "default": null,
           "description": "Specifies path to home directory of Cargo. Mostly needed for working with custom installations of Rust via rustup or multirust."
         },
+        "rust.cargoEnv": {
+          "type": ["object", "null"],
+          "default": null,
+          "description": "Specifies custom variables to set when running cargo. Useful for crates which use env vars in their build.rs (like openssl-sys)."
+        },
         "rust.formatOnSave": {
           "type": "boolean",
           "default": false,

--- a/src/services/commandService.ts
+++ b/src/services/commandService.ts
@@ -76,6 +76,12 @@ class CargoTask {
             this.channel.append(this, `Running "${task}":\n`);
 
             let newEnv = Object.assign({}, process.env);
+
+            let customEnv = vscode.workspace.getConfiguration('rust')['cargoEnv'];
+            if (customEnv) {
+                newEnv = Object.assign(newEnv, customEnv);
+            }
+
             if (errorFormat === ErrorFormat.JSON) {
                 newEnv['RUSTFLAGS'] = '-Zunstable-options --error-format=json';
             } else if (errorFormat === ErrorFormat.NewStyle) {


### PR DESCRIPTION
rust.cargoEnv can be used to set custom environment variables when running
cargo. This is useful for compiling some crates like openssl-sys.

For example to compile openssl-sys on osx with openssl from homebrew, the
following can be set in settings.json:

    "rust.cargoEnv": {
        "OPENSSL_INCLUDE_DIR": "/usr/local/opt/openssl/include",
        "OPENSSL_LIB_DIR": "/usr/local/opt/openssl/lib"
    }