### PR TITLE
Remove Documentation Line Count Limitation

### DIFF
--- a/src/services/suggestService.ts
+++ b/src/services/suggestService.ts
@@ -264,11 +264,6 @@ export default class SuggestService {
             }
 
             for (let i = 0; i < docs.length; i++) {
-                if (i >= 15 && docs.length !== 16 && !codeBlock) {
-                    currentBlock.push('...');
-                    break;
-                }
-
                 let docLine = docs[i];
 
                 if (docLine.trim().startsWith('```')) {


### PR DESCRIPTION
This limitation was necessary before 1.9, as the tooltips would fill up the whole screen before. Tooltips now have scrollbars though, so we can finally show the whole documentation again.

Fixes #185
