### PR TITLE
Added `cargo clippy` task to the list of commands.

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,11 @@
         "description": "Check the main library of the project for warnings and errors"
       },
       {
+        "command": "rust.cargo.clippy",
+        "title": "Cargo: Clippy",
+        "description": "Check project with clippy."
+      },
+      {
         "command": "rust.cargo.terminate",
         "title": "Cargo: Terminate Running Task",
         "description": "Terminate currently running cargo task"


### PR DESCRIPTION
In a big project `cargo clippy` may take up to several minutes to run. It is not viable to set as default linter in this case. But it is useful to have an ability to call `cargo clippy` manually whenever it is needed.

This is related to #145.