### PR TITLE
Command to show/hide output panel.

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,11 @@
         "command": "rust.cargo.terminate",
         "title": "Cargo: Terminate Running Task",
         "description": "Terminate currently running cargo task"
+      },
+      {
+        "command": "rust.cargo.output.toggle",
+        "title": "Cargo: Toggle Output",
+        "description": "Show/hide output panel"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -159,4 +159,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
     // Cargo terminate
     ctx.subscriptions.push(CommandService.stopCommand('rust.cargo.terminate'));
+
+    // Toggle output panel
+    ctx.subscriptions.push(CommandService.toggleChannel('rust.cargo.output.toggle'));
 }

--- a/src/services/commandService.ts
+++ b/src/services/commandService.ts
@@ -25,9 +25,11 @@ export enum ErrorFormat {
 class ChannelWrapper {
     private owner: CargoTask;
     private channel: vscode.OutputChannel;
+    private isVisible: boolean;
 
     constructor(channel: vscode.OutputChannel) {
         this.channel = channel;
+        this.isVisible = false;
     }
 
     public append(task: CargoTask, message: string): void {
@@ -44,6 +46,20 @@ class ChannelWrapper {
 
     public show(): void {
         this.channel.show(true);
+        this.isVisible = true;
+    }
+
+    public hide(): void {
+        this.channel.hide();
+        this.isVisible = false;
+    }
+
+    public toggle(): void {
+        if (this.isVisible) {
+            this.hide();
+        } else {
+            this.show();
+        }
     }
 
     public setOwner(owner: CargoTask): void {
@@ -195,6 +211,12 @@ export class CommandService {
             if (this.currentTask) {
                 this.currentTask.kill();
             }
+        });
+    }
+
+    public static toggleChannel(commandName: string): vscode.Disposable {
+        return vscode.commands.registerCommand(commandName, () => {
+            this.channel.toggle();
         });
     }
 


### PR DESCRIPTION
If #198 will be merged, it would be useful to have a command that toggles Cargo output panel visibility.