### PR TITLE
Removed TOML from Rust language file extensions and added all commands to activation events

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,25 @@
     "Snippets"
   ],
   "activationEvents": [
-    "onLanguage:rust"
+    "onLanguage:rust",
+    "workspaceContains:Cargo.toml",
+    "onCommand:rust.cargo.build.example.debug",
+    "onCommand:rust.cargo.build.example.release",
+    "onCommand:rust.cargo.run.example.debug",
+    "onCommand:rust.cargo.run.example.release",
+    "onCommand:rust.cargo.build.debug",
+    "onCommand:rust.cargo.build.release",
+    "onCommand:rust.cargo.run.debug",
+    "onCommand:rust.cargo.run.release",
+    "onCommand:rust.cargo.doc",
+    "onCommand:rust.cargo.test.debug",
+    "onCommand:rust.cargo.test.release",
+    "onCommand:rust.cargo.bench",
+    "onCommand:rust.cargo.update",
+    "onCommand:rust.cargo.clean",
+    "onCommand:rust.cargo.check",
+    "onCommand:rust.cargo.check.lib",
+    "onCommand:rust.cargo.terminate"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -35,7 +53,6 @@
           "Rust"
         ],
         "extensions": [
-          ".toml",
           ".rs"
         ]
       }


### PR DESCRIPTION
Issues #138 and #170 correctly mention that RustyCode should not specify __.toml__ files as Rust source code files. Right now there are two TOML plugins for VSCode: [better-toml](https://github.com/bungcip/better-toml) and [toml](https://marketplace.visualstudio.com/items?itemName=be5invis.toml), both have syntax coloring, that is being replaced by Rust's syntax. It seems this behaviour depends on the loading order of plugins, which can be different for different environments, but it certainly happens for me. Also there is an issue of `rustfmt` being ran against TOML files.

PR #171 solves this issue by adding TOML syntax to RustyCode, but I believe this should be left for separate extensions to implement (after all, TOML is not only used in Rust projects exclusively).

In #170 @KalitaAlexey mentions that the main reason `.toml` is included in the list of Rust extensions, is because otherwise Cargo commands can only be ran if __.rs__ file is open. Indeed, plugin only activates after Rust language file opens.

I believe, that currently, the best way to solve this, is to list all RustyCode command contributions in `activationEvents`. There is a downside though- the `activationEvents` list will have to be updated every time when commands will be added or changed (at least for now: Microsoft/vscode#16045).