### PR TITLE
Skipping hidden lines in doc examples

### DIFF
--- a/src/services/suggestService.ts
+++ b/src/services/suggestService.ts
@@ -270,7 +270,10 @@ export default class SuggestService {
                 }
 
                 let docLine = docs[i];
-
+                
+                if (docLine.trim().startsWith('#')) {
+                    continue;
+                } else
                 if (docLine.trim().startsWith('```')) {
                     if (currentBlock.length) {
                         pushBlock();

--- a/src/services/suggestService.ts
+++ b/src/services/suggestService.ts
@@ -270,7 +270,7 @@ export default class SuggestService {
                 }
 
                 let docLine = docs[i];
-                
+
                 if (docLine.trim().startsWith('#')) {
                     continue;
                 } else


### PR DESCRIPTION
As per the [Rust book](https://doc.rust-lang.org/book/documentation.html), lines in codeblocks in documentation comments starting with # are not rendered. I think they should be hidden in the docs hover too – code checks if line starts with # and skips this line.